### PR TITLE
appboard(ch07s05): Applying Fault Tolerance Policies to Quarkus Microservices

### DIFF
--- a/tolerance-review/AppFlow.adoc
+++ b/tolerance-review/AppFlow.adoc
@@ -11,8 +11,28 @@ The present lab makes use of Session, Speaker and Schedule services.
 
 * `Aliveness` and `Readiness` checks are implemented.
 * Prepare the Session service to use `fault tolerance` features.
-* Create a `fallback` and enable the fault tolerance policy.
+* Apply `fallback` policies to an exisitng method and enable the fault tolerance policy.
 * Create a fallback method for returning `non-enriched` speaker information.
 * Adding a `fake delay` to the endpoint method used by other external client.
 * Implementing `retry policy` on methods during unavailability.
 * Protect the methods from `concurrent requests`.
+
+== Proposed App Flow
+
+The proposed lab makes use of Session, Speaker and Schedule services.
+
+* `Aliveness` and `Readiness` checks are implemented.
+* Prepare the Session service to use `fault tolerance` features.
+* Apply `fallback` policies to an exisitng method and enable the fault tolerance policy.
+* Create a fallback method for returning `non-enriched` speaker information.
+* Adding a `fake delay` to the endpoint method used by other external client.
+* Implementing `retry policy` on methods during unavailability.
+* Implement `Circuit Breaker` resiliency.
+
+== Links
+
+https://role.rhu.redhat.com/rol-rhu/app/courses/do378-1.11/pages/ch05s05
+
+https://github.com/RedHatTraining/DO378/tree/main/classroom/materials/solutions/tolerance-review
+
+https://es.quarkus.io/version/2.7/guides/smallrye-fault-tolerance#adding-resiliency-circuit-breaker

--- a/tolerance-review/AppFlow.adoc
+++ b/tolerance-review/AppFlow.adoc
@@ -1,0 +1,18 @@
+:gls_prefix:
+
+// Do not modify section headers, as they are used by flamel and the translation process.
+= pass:a,n[{gls_res_outcomes}]
+
+You should be able to apply different fault tolerance policies to Quarkus applications given identified potential faults.
+
+== Present App Flow
+
+The present lab makes use of Session, Speaker and Schedule services.
+
+* `Aliveness` and `Readiness` checks are implemented.
+* Prepare the Session service to use `fault tolerance` features.
+* Create a `fallback` and enable the fault tolerance policy.
+* Create a fallback method for returning `non-enriched` speaker information.
+* Adding a `fake delay` to the endpoint method used by other external client.
+* Implementing `retry policy` on methods during unavailability.
+* Protect the methods from `concurrent requests`.


### PR DESCRIPTION
Hi Team,

I am working on the proposed app flow for the lab. 

According to me, the present lab fulfills everything and is properly aligned. A few changes can be done such as:
* We can update the apps of _Schedule, Session and Speaker Services_.
* We can implement the fault tolerance policies on a different set of methods involved.

It is open for discussion and we can settle on it once everyone has their opinion.

Thanks
