### PR TITLE
fix(ch03s04): Make test suites independent

### DIFF
--- a/test-mock/apps/expenses-service/src/test/java/com/redhat/training/expense/CrudTest.java
+++ b/test-mock/apps/expenses-service/src/test/java/com/redhat/training/expense/CrudTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.*;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.*;
 
-
 @QuarkusTest
 @TestHTTPEndpoint(ExpenseResource.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -142,6 +141,33 @@ public class CrudTest {
         .then()
             .statusCode(404);
     }
+
+    @Test
+    @Order(5)
+    public void deleteExistingExpenseReturns204() {
+        // Getting the list of expenses
+        Response expense = given()
+                .when()
+                    .get()
+                .then()
+                    .statusCode(200)
+                    .body("$.size()", is(1))
+                    .extract()
+                    .response();
+
+        // Extracting the UUID of the stored expense
+        String expenseUuid = expense
+                .jsonPath()
+                .getString("[0].uuid");
+
+        given()
+            .pathParam("uuid", expenseUuid)
+        .when()
+            .delete("/{uuid}")
+        .then()
+            .statusCode(204);
+    }
+
 
     public static String generateExpenseJson(String uuid, String expenseName, String paymentType, double amount) {
         return "{"

--- a/test-mock/apps/expenses-service/src/test/java/com/redhat/training/expense/RestClientMockTest.java
+++ b/test-mock/apps/expenses-service/src/test/java/com/redhat/training/expense/RestClientMockTest.java
@@ -3,6 +3,7 @@ package com.redhat.training.expense;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
 import io.restassured.http.ContentType;
+
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/test-mock/apps/expenses-service/src/test/java/com/redhat/training/expense/ServiceMockTest.java
+++ b/test-mock/apps/expenses-service/src/test/java/com/redhat/training/expense/ServiceMockTest.java
@@ -3,6 +3,7 @@ package com.redhat.training.expense;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
 import io.restassured.http.ContentType;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 

--- a/test-mock/solutions/expenses-service/src/test/java/com/redhat/training/expense/CrudTest.java
+++ b/test-mock/solutions/expenses-service/src/test/java/com/redhat/training/expense/CrudTest.java
@@ -142,6 +142,33 @@ public class CrudTest {
             .statusCode(404);
     }
 
+    @Test
+    @Order(5)
+    public void deleteExistingExpenseReturns204() {
+        // Getting the list of expenses
+        Response expense = given()
+                .when()
+                    .get()
+                .then()
+                    .statusCode(200)
+                    .body("$.size()", is(1))
+                    .extract()
+                    .response();
+
+        // Extracting the UUID of the stored expense
+        String expenseUuid = expense
+                .jsonPath()
+                .getString("[0].uuid");
+
+        given()
+            .pathParam("uuid", expenseUuid)
+        .when()
+            .delete("/{uuid}")
+        .then()
+            .statusCode(204);
+    }
+
+
     public static String generateExpenseJson(String uuid, String expenseName, String paymentType, double amount) {
         return "{"
                 + (uuid.isEmpty() ? "" : "\"uuid\":\"" + uuid + "\",")

--- a/test-mock/solutions/expenses-service/src/test/java/com/redhat/training/expense/SpyTest.java
+++ b/test-mock/solutions/expenses-service/src/test/java/com/redhat/training/expense/SpyTest.java
@@ -8,7 +8,6 @@ import org.mockito.Mockito;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
 
-
 @QuarkusTest
 public class SpyTest {
 


### PR DESCRIPTION
- Synchronizing apps and solutions dirs
- Ensuring that the Crud testsuite leaves DB in a consistent state for other DBs