### PR TITLE
fix(deploy-binding): Switch service to docker deployment

### DIFF
--- a/deploy-binding/apps/expenses-service/src/main/resources/application.properties
+++ b/deploy-binding/apps/expenses-service/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 quarkus.devservices.enabled = false
 quarkus.openshift.route.expose = true
 quarkus.kubernetes.deploy = true
+quarkus.openshift.build-strategy=docker
 quarkus.hibernate-orm.database.generation = drop-and-create

--- a/deploy-binding/solutions/expenses-service/src/main/resources/application.properties
+++ b/deploy-binding/solutions/expenses-service/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 quarkus.devservices.enabled = false
 quarkus.openshift.route.expose = true
 quarkus.kubernetes.deploy = true
+quarkus.openshift.build-strategy=docker
 quarkus.hibernate-orm.database.generation = drop-and-create
 
 quarkus.kubernetes-service-binding.services.expenses-db.api-version = postgres-operator.crunchydata.com/v1beta1


### PR DESCRIPTION
The S2I strategy applies an ImageStream that points to public external builder images. Disconnected environments won't be able to pull these images